### PR TITLE
passing namespace correctly / added more tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,11 @@ const postcssKremling = require('./src/postcss-kremling-plugin');
 
 module.exports = function(source) {
   const loaderOptions = getOptions(this) || {};
-  let kremlingNamespace = '';
+  let kremlingNamespace = 'data-kremling';
+  let kremlingNamespaceString = '';
   if (loaderOptions.namespace && typeof loaderOptions.namespace === 'string') {
-    kremlingNamespace = `namespace: '${loaderOptions.namespace}'`;
+    kremlingNamespace = loaderOptions.namespace;
+    kremlingNamespaceString = `namespace: '${loaderOptions.namespace}'`;
   }
   const defaultOptions = {
     plugins: {},
@@ -20,7 +22,7 @@ module.exports = function(source) {
   });
 
   const callback = this.async();
-  postcss([ ...pluginsInit, postcssKremling() ])
+  postcss([ ...pluginsInit, postcssKremling(kremlingNamespace)() ])
     .process(source, {
       ...restOfOptions,
       to: './',
@@ -28,9 +30,9 @@ module.exports = function(source) {
     })
     .then((result) => {
       if (result.css) {
-        callback(null, `module.exports = { styles: '${result.toString().replace(/(\s)+/g, ' ')}', id: '${kremId.id}', ${kremlingNamespace} };`);
+        callback(null, `module.exports = { styles: '${result.toString().replace(/(\s)+/g, ' ').replace(/'/g, `\\'`)}', id: '${kremId.id}', ${kremlingNamespaceString} };`);
       } else {
-        callback(null, `module.exports = { styles: '', id: '${kremId.id}', ${kremlingNamespace} };`);
+        callback(null, `module.exports = { styles: '', id: '${kremId.id}', ${kremlingNamespaceString} };`);
       }
     });
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kremling-loader",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "index.js",
   "author": "@geoctrl",
   "license": "MIT",

--- a/src/postcss-kremling-plugin.js
+++ b/src/postcss-kremling-plugin.js
@@ -2,29 +2,31 @@ const postcss = require('postcss');
 const parser = require('postcss-selector-parser');
 const kremId = require('./kremling-id');
 
-function parseSelectors(ruleSelectors, space) {
-  return parser(selectors => {
-    selectors.each(selector => {
-      const attr = parser.attribute({ attribute: `data-kremling="${kremId.id}"` });
-      const combinator = parser.combinator({ value: ' ' });
+module.exports = function(namespace) {
+  function parseSelectors(ruleSelectors, space) {
+    return parser(selectors => {
+      selectors.each(selector => {
+        const attr = parser.attribute({ attribute: `${namespace}="${kremId.id}"` });
+        const combinator = parser.combinator({ value: ' ' });
+  
+        if (selector.at(0).type === 'class' || selector.at(0).type == 'id' || space) {
+          selector.insertBefore(selector.at(0), attr);
+          if (space) selector.insertAfter(selector.at(0), combinator);
+        } else {
+          selector.insertAfter(selector.at(0), attr);
+        }
+        return selector;
+      });
+    }).processSync(ruleSelectors, { lossless: false });
+  }  
 
-      if (selector.at(0).type === 'class' || selector.at(0).type == 'id' || space) {
-        selector.insertBefore(selector.at(0), attr);
-        if (space) selector.insertAfter(selector.at(0), combinator);
-      } else {
-        selector.insertAfter(selector.at(0), attr);
-      }
-      return selector;
-    });
-  }).processSync(ruleSelectors, { lossless: false });
+  return postcss.plugin('postcss-kremling-plugin', function () {
+    return function (root) {
+      kremId.increment();
+      root.walkRules(function (rule) {
+        rule.selector = `${parseSelectors(rule.selector, true)},${parseSelectors(rule.selector, false)}`;
+        return rule;
+      });
+    };
+  });
 }
-
-module.exports = postcss.plugin('postcss-kremling-plugin', function () {
-  return function (root) {
-    kremId.increment();
-    root.walkRules(function (rule) {
-      rule.selector = `${parseSelectors(rule.selector, true)},${parseSelectors(rule.selector, false)}`;
-      return rule;
-    });
-  };
-});

--- a/test/kremling-loader.test.js
+++ b/test/kremling-loader.test.js
@@ -1,18 +1,6 @@
-const kremlingLoader = require('../index');
 const kremlingId = require('../src/kremling-id');
-const { parseEsModuleString } = require('./utils');
+const { parseEsModuleString, webpackMock } = require('./utils');
 
-function webpackMock() {
-  this.test = null;
-  this.async = () => (err, result) => {
-    return this.test(result);
-  };
-  this.loader = kremlingLoader;
-  this.run = (source, test) => {
-    this.test = test;
-    this.loader(source);
-  };
-}
 const mockKremlingLoader = new webpackMock();
 
 describe('kremling-loader', () => {
@@ -21,21 +9,21 @@ describe('kremling-loader', () => {
   });
 
   test('should output a valid es module', done => {
-    mockKremlingLoader.run('.a{}', result => {
+    mockKremlingLoader.run('.a{}', null, result => {
       expect(!!parseEsModuleString(result)).toBe(true);  
       done();
     });
   });
 
   test('should prepend all selectors with kremling selector', done => {
-    mockKremlingLoader.run('.a{}', result => {
+    mockKremlingLoader.run('.a{}', null, result => {
       expect(parseEsModuleString(result).styles).toBe('[data-kremling="1"] .a,[data-kremling="1"].a{}');
       done();
     })
   });
 
   test('should reverse order of the first selector if the selector is not a class or id', done => {
-    mockKremlingLoader.run('[title]{}', result => {
+    mockKremlingLoader.run('[title]{}', null, result => {
       expect(parseEsModuleString(result).styles).toBe('[data-kremling="1"] [title],[title][data-kremling="1"]{}');
       done();
     });
@@ -49,9 +37,56 @@ describe('kremling-loader', () => {
       }`;
 
     const newCss = '[data-kremling="1"] .okay,[data-kremling="1"] input,[data-kremling="1"].okay,input[data-kremling="1"] { background-color: red; }';
-      mockKremlingLoader.run(css, result => {
+      mockKremlingLoader.run(css, null, result => {
         expect((parseEsModuleString(result).styles).trim()).toEqual(newCss.trim());
         done();
       });
+  });
+
+  test('should use namespace from webpack options', done => {
+    const css = `
+      .okay {background-color: red;}
+    `;
+    const newCss = `[pizza="1"] .okay,[pizza="1"].okay {background-color: red;}`
+    const options = { namespace: 'pizza' };
+    mockKremlingLoader.run(css, options, result => {
+      const resultObj = parseEsModuleString(result);
+      expect((resultObj.styles).trim()).toEqual(newCss.trim());
+      expect(resultObj.namespace).toEqual(options.namespace);
+      done();
+    });
+  });
+
+  test('should allow double and single quotes without blowing up', done => {
+    const css = `
+      .okay {
+        content: '';
+        content: "";
+      }
+    `;
+    mockKremlingLoader.run(css, null, result => {
+      expect(!!parseEsModuleString(result).styles).toBe(true)
+      done();
+    });
+  });
+
+  test('should use postcss plugins from webpack config options', done => {
+    const css = `
+      .okay {
+        transform: scale(2);
+      }
+    `;
+    const options = {
+      postcss: {
+        plugins: {
+          autoprefixer: {}
+        },
+      },
+    };
+    mockKremlingLoader.run(css, options, result => {
+      const resultObj = parseEsModuleString(result);
+      expect(resultObj.styles.indexOf('-webkit-transform') > -1).toBe(true);
+      done();
+    });
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,21 @@
+const kremlingLoader = require('../index');
+
 exports.parseEsModuleString = function(str) {
   // make sure this is an es module
   if (str.indexOf('module.exports = ') !== 0) return false;
   const toParse = `(${str.substring(0, str.length - 1).slice(16).trim()})`;
   return eval(toParse);
+}
+
+exports.webpackMock = function() {
+  this.test = null;
+  this.async = () => (err, result) => {
+    return this.test(result);
+  };
+  this.loader = kremlingLoader;
+  this.run = (source, options, test) => {
+    if (options) this.query = `?${JSON.stringify(options)}`;
+    this.test = test;
+    this.loader(source);
+  };
 }


### PR DESCRIPTION
- `namespace` is now being passed in to the internal kremling postcss plugin correctly
- single-quotes are now escaped in the returned styles string
- testing webpack options more thoroughly (namespace and postcss options)