### PR TITLE
pass full kremling id to postcss plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,12 +20,12 @@ module.exports = function(source) {
   };
 
   const { plugins, ...restOfOptions } = defaultOptions;
-  pluginsInit = (Object.keys(plugins)).map(key => {
+  const pluginsInit = (Object.keys(plugins)).map(key => {
     return require(key)(plugins[key]);
   });
 
   const callback = this.async();
-  postcss([ ...pluginsInit, postcssKremling(id, kremlingNamespace)() ])
+  postcss([ ...pluginsInit, postcssKremling(`p${id}`, kremlingNamespace)() ])
     .process(source, {
       ...restOfOptions,
       to: './',

--- a/src/postcss-kremling-plugin.js
+++ b/src/postcss-kremling-plugin.js
@@ -5,7 +5,7 @@ module.exports = function(id, namespace) {
   function parseSelectors(ruleSelectors, space) {
     return parser(selectors => {
       selectors.each(selector => {
-        const attr = parser.attribute({ attribute: `${namespace}="p${id}"` });
+        const attr = parser.attribute({ attribute: `${namespace}="${id}"` });
         const combinator = parser.combinator({ value: ' ' });
   
         if (selector.at(0).type === 'class' || selector.at(0).type === 'id' || space) {


### PR DESCRIPTION
this allows us to use other letters for different kremling applications (kremling-babel-plugin will use `k*`)