### PR TITLE
v2.1.1 - fix keyframes

### DIFF
--- a/dev-env/main.css
+++ b/dev-env/main.css
@@ -1,3 +1,13 @@
 input .test {
   text-align: center;
+  animation: my-animation;
+}
+
+@keyframes my-animation {
+  from {
+    background-color: red;
+  }
+  to {
+    background-color: blue;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kremling-loader",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "index.js",
   "author": "@geoctrl",
   "license": "MIT",

--- a/src/postcss-kremling-plugin.js
+++ b/src/postcss-kremling-plugin.js
@@ -6,7 +6,7 @@ module.exports = ({ id, namespace }) => {
     const output = parser(selectors => {
       if (left) {
         const s = selectors.first.first;
-        if (s.type === 'pseudo') {
+        if (s.type === 'pseudo' || s.type === 'tag') {
           if (s.value === ':global') {
             s.remove();
           }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ config.module = {
               plugins: {
                 'autoprefixer': {},
                 'cssnano': {},
-              },  
+              },
             },
           },
         },


### PR DESCRIPTION
fix `kremling-postcss-plugin` to allow for the `@keyframe` at-rule - basically the nested "steps" don't need to be scoped

what it used to do:
```css
@keyframe custom-anim {
  [kremling=1]from, [kremling=1] from {
    background-color: red;
  }
  [kremling=1]to, [kremling=1] to {
    background-color: red;
  }
}
```

with the fix:
```css
@keyframe custom-anim {
  from {
    background-color: red;
  }
  to {
    background-color: red;
  }
}
```
